### PR TITLE
content_tag_for istead of content_tag for producing table rows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,6 @@ group :development, :test do
   gem "autotest"
   gem "webrat"
 
-  case RUBY_VERSION
-  when /^1\.9/
-    gem 'ruby-debug19'
-  when /^1\.8/
-    gem 'ruby-debug'
-  end
+  gem 'ruby-debug19', :platforms => :ruby_19
+  gem 'ruby-debug', :platforms => :ruby_18
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require "rspec/core/rake_task"
 
+task :default => :spec
+
 desc "Test table_for_collection plugin."
 RSpec::Core::RakeTask.new('spec')
 

--- a/lib/table_for/callback_column.rb
+++ b/lib/table_for/callback_column.rb
@@ -6,7 +6,7 @@ module TableHelper
     end
 
     def content_for(record)
-      @attr ? @callback.call(record.send(@attr).to_s) : @callback.call(record)
+      @attr ? @callback.call(record.send(@attr)) : @callback.call(record)
     end
   end
 end

--- a/lib/table_for/table.rb
+++ b/lib/table_for/table.rb
@@ -2,7 +2,7 @@ require "core_ex/array"
 
 module TableHelper
   class Table # :nodoc:
-    delegate :content_tag, :to => :@template
+    delegate :content_tag, :content_tag_for, :to => :@template
     
     def initialize(template, records, options = {})
       @template, @records, @columns = template, records, []
@@ -17,7 +17,7 @@ module TableHelper
 
     def columns(*args)
       res = []
-      unless args.blank?
+      if args.present?
         args.each do |arg|
           res << self.column(arg)
         end
@@ -69,7 +69,7 @@ module TableHelper
     def body
       content_tag :tbody do
         @records.map do |rec|
-          content_tag(:tr, tr_options) do
+          content_tag_for :tr, rec, tr_options do
             @columns.map do |col|
               content_tag :td, col.html[:td] do
                 col.content_for(rec).to_s
@@ -84,11 +84,7 @@ module TableHelper
       res = @tr_html_options.nil? ? {} : @tr_html_options.clone
       html_class = @stripes.next
       unless html_class.nil?
-        if res.has_key?(:class)
-          res[:class] += " " + html_class
-        else
-          res.merge!({ :class => html_class })
-        end
+        res[:class] = [res[:class], html_class].compact.join(" ")
       end
       res
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,14 @@ shared_examples_for "Column class instance" do
   end
 end
 
+class User < OpenStruct
+  extend ActiveModel::Naming
+
+  def id
+    @id
+  end
+end
+
 RSpec.configure do |config|
   config.include(Webrat::Matchers)
 end

--- a/spec/table_for/table_spec.rb
+++ b/spec/table_for/table_spec.rb
@@ -8,14 +8,14 @@ describe TableHelper::Table do
   # users list (stubbed data)
   let(:users) do
     [
-      mock(:id => 1,
-           :name => "John Jackson",
-           :email => "john.jackson@example.com",
-           :address => "100, Spear Street, LA, USA"),
-      mock(:id => 2,
-           :name => "Jack Johnson",
-           :email => "jack.johnson@example.com",
-           :address => "12, Brooklin, NY, USA"),
+      User.new(:id => 1,
+               :name => "John Jackson",
+               :email => "john.jackson@example.com",
+               :address => "100, Spear Street, LA, USA"),
+      User.new(:id => 2,
+               :name => "Jack Johnson",
+               :email => "jack.johnson@example.com",
+               :address => "12, Brooklin, NY, USA"),
     ]
   end
   # table instance

--- a/spec/table_for_collection_spec.rb
+++ b/spec/table_for_collection_spec.rb
@@ -8,29 +8,29 @@ describe ActionView::Base do
   # users list (stubbed data)
   let(:users) do
     [
-      mock({
+      User.new({
         :id => 1209,
         :name => "John Smith",
         :email => "smith@matrix.net",
-        :address => "100, Spear Street, NY, USA",
+        :address => "100, Spear Street, NY, USA"
       }),
-      mock({
+      User.new({
         :id => 2123,
         :name => "Thomas Anderson",
         :email => "neo@matrix.net",
-        :address => "200, Spear Street, NY, USA",
+        :address => "200, Spear Street, NY, USA"
       }),
-      mock({
+      User.new({
         :id => 3323,
         :name => "Trinity",
         :email => "trinity@matrix.net",
-        :address => "300, Spear Street, NY, USA",
+        :address => "300, Spear Street, NY, USA"
       }),
-      mock({
+      User.new({
         :id => 4912,
         :name => "Morpheus",
         :email => "morpheus@matrix.net",
-        :address => "400, Spear Street, NY, USA",
+        :address => "400, Spear Street, NY, USA"
       })
     ]
   end


### PR DESCRIPTION
We need to use sortable-behavior for table rows in our project, so we need them to have classes and ids from associated records.
