### PR TITLE
Changed source for Gemfile to https://rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :gemcutter
+source 'https://rubygems.org'
 
 gem "actionpack"
 


### PR DESCRIPTION
I got the following error;

```
The source :gemcutter is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```

This PR fixes that issue.
